### PR TITLE
Optimize fatal error checks

### DIFF
--- a/src/Infrastructure/FunctionControllerBase.cs
+++ b/src/Infrastructure/FunctionControllerBase.cs
@@ -175,7 +175,6 @@
             re: switch (ex)
             {
                 case OutOfMemoryException _:
-                case StackOverflowException _:
                     return true;
                 case AggregateException { InnerException: { }, // avoids allocation if collection is empty
                                           InnerExceptions: var iexs }:


### PR DESCRIPTION
Hello @fbeltrao 👋🏼

This PR recommends a more optimised and simpler version of `IsFatal` method in `FunctionControllerBase`. The proposed benefits are:

- It's 5 lines shorter!
- The data conditions stand out as expectations, which is easier than human-parsing & reading if-else branches
- There are fewer allocations. [`InnerExceptions` allocates a collection unconditionally](https://github.com/dotnet/runtime/blob/fe80a77dac16de2451be60563123b8fbf8ea8355/src/libraries/System.Private.CoreLib/src/System/AggregateException.cs#L244), even when it is empty. The [`AggregateException.InnerException` (singular) represents the first error or `null` if empty](https://github.com/dotnet/runtime/blob/fe80a77dac16de2451be60563123b8fbf8ea8355/src/libraries/System.Private.CoreLib/src/System/AggregateException.cs#L104) so the `InnerException: { }` will only match and cause a collection allocation if `InnerExceptions` (plural) isn't empty.
- The `foreach` loop over `AggregateException.InnerExceptions` has been re-written as a `for` loop to avoid allocating [an enumerator over the collection](https://github.com/dotnet/runtime/blob/fe80a77dac16de2451be60563123b8fbf8ea8355/src/libraries/System.Private.CoreLib/src/System/Collections/ObjectModel/ReadOnlyCollection.cs#L40-L43). It also avoids a try-catch setup by the compiler since enumerators need disposing, but that's excessive since we know this is an in-memory collection. A side-effect of this is that it can also lead to more JIT optimisations due to simpler code.
- Avoiding the unnecessary allocations highlighted in the previous two points is worthwhile for a function that may called in fatal circumstances.

Yes, there's a `goto` 😱 in there, but it's to avoid stack-based recursion. I hope you'll agree this is a fair, clear and judicious use of `goto` in a small control block. Another option would have been to re-wirte the function for tail call recursion that can be optimised away very well by JIT. That would look like this if you want to get rid of the `goto`:

```c#
private bool IsFatal(Exception ex)
{
    switch (ex)
    {
        case OutOfMemoryException _:
        case StackOverflowException _:
            return true;
        case AggregateException { InnerException: { }, // avoids allocation if collection is empty
                                  InnerExceptions: var iexs }:
            for (var i = 0; i < iexs.Count; i++)
            {
                if (IsFatal(iexs[i]))
                    return true;
            }

            return false;
        case { InnerException: { } iex }:
            ex = iex;
            break;
        default:
            return false;
    }

    return IsFatal(ex);
}
```

The machine code from JIT compilation demonstrates that tail call optimisation at offset `L006f`, where there's a jump instruction to near the top (`jmp short L000d`):

```asm
C.IsFatal(System.Exception)
    L0000: push rdi
    L0001: push rsi
    L0002: push rbx
    L0003: sub rsp, 0x20
    L0007: mov rdi, rcx
    L000a: mov rsi, rdx
    L000d: mov rdx, rsi
    L0010: mov rcx, 0x7ffabc2543f0
    L001a: call 0x00007ffb1bcc6660
    L001f: test rax, rax
    L0022: jne L00e7
    L0028: mov rdx, rsi
    L002b: test rdx, rdx
    L002e: je short L0041
    L0030: mov rcx, 0x7ffabc2544f0
    L003a: cmp [rdx], rcx
    L003d: je short L0041
    L003f: xor edx, edx
    L0041: test rdx, rdx
    L0044: jne L00e7
    L004a: mov rdx, rsi
    L004d: mov rcx, 0x7ffabc3c3e20
    L0057: call 0x00007ffb1bcc6660
    L005c: test rax, rax
    L005f: jne short L0071
    L0061: test rsi, rsi
    L0064: je short L00dd
    L0066: mov rsi, [rsi+0x20]
    L006a: test rsi, rsi
    L006d: je short L00dd
    L006f: jmp short L000d
    L0071: mov rsi, [rax+0x20]
    L0075: test rsi, rsi
    L0078: je short L00dd
    L007a: mov rsi, [rax+0x78]
    L007e: xor ebx, ebx
    L0080: mov rcx, [rsi+8]
    L0084: mov r11, 0x7ffac32a7028
    L008e: cmp [rcx], ecx
    L0090: call qword ptr [0x7ffac32a7028]
    L0096: test eax, eax
    L0098: jle short L00dd
    L009a: mov rcx, [rsi+8]
    L009e: mov edx, ebx
    L00a0: mov r11, 0x7ffac32a7020
    L00aa: cmp [rcx], ecx
    L00ac: call qword ptr [0x7ffac32a7020]
    L00b2: mov rdx, rax
    L00b5: mov rcx, rdi
    L00b8: call C.IsFatal(System.Exception)
    L00bd: test eax, eax
    L00bf: jne short L00e7
    L00c1: inc ebx
    L00c3: mov rcx, [rsi+8]
    L00c7: mov r11, 0x7ffac32a7028
    L00d1: cmp [rcx], ecx
    L00d3: call qword ptr [0x7ffac32a7028]
    L00d9: cmp eax, ebx
    L00db: jg short L009a
    L00dd: xor eax, eax
    L00df: add rsp, 0x20
    L00e3: pop rbx
    L00e4: pop rsi
    L00e5: pop rdi
    L00e6: ret
    L00e7: mov eax, 1
    L00ec: add rsp, 0x20
    L00f0: pop rbx
    L00f1: pop rsi
    L00f2: pop rdi
    L00f3: ret
    L00f4: movzx eax, al
    L00f7: add rsp, 0x20
    L00fb: pop rbx
    L00fc: pop rsi
    L00fd: pop rdi
    L00fe: ret
```

[See also on sharplab.io](https://sharplab.io/#v2:EYLgxg9gTgpgtADwGwBYA0AXEBDAzgWwB8ABAJgEYBYAKGIGYACMhgYQYG8aHuGAHKAJYA3bBhgNgECABsGASVwAxUdmkAKAKIIwMXhgEQAdgxgIAlFx6dqPWw1wB3ARjAALBmtMWbd7td++YHjiAPIArhghAGYAsjD40ACeWjp6BsYA+iCWATxBuOIAyhjYYADWIUIwUFHSEA4puvpGDFk5uXbEAOwMGFBhMADc7bn54gCCAOaTsJOiMI1pLezyhobVi82GIBwMAL5oDAD0RwzYxCi4Z9J1QVsMAlEMkDcwYPcCV/F6iSMd/wCeHI1httE10rgdiIoA9TFc9tkfIDuFFoB5oQ8GABeBgABkGmIAPLCELgAHQsCBhQwYAkCADU9O8yKsfxZjw8CmUJXUAjhAG0BABdMzMlkdbq9fpDNkdPY0WW5SVRVQFYZIjpjXbA9ZQTbpHYrPYk/aI8UmBDYknq83AWDYMo2gEAExgKrC0iwioCytVMo1tnl1Flkq5KnUXid3CDeyAA==).

However, I think the `goto` is more explicit and clear rather than relying on runtime black magic. Moreover, since we hope `IsFatal` isn't a hot path, [tiered-compilation](https://devblogs.microsoft.com/dotnet/tiered-compilation-preview-in-net-core-2-1/) means that JIT optimisations may not even kick in all the time. Anyway, hope I've made the special case for `goto` here. :wink:

---
/cc @p-schuler, @marcgs, @algattik
