### PR TITLE
Remove stack overflow check that cannot be caught

### DIFF
--- a/src/Infrastructure/FunctionControllerBase.cs
+++ b/src/Infrastructure/FunctionControllerBase.cs
@@ -167,8 +167,7 @@
 
         private bool IsFatal(Exception ex)
         {
-            if (ex is StackOverflowException ||
-                ex is OutOfMemoryException)
+            if (ex is OutOfMemoryException)
             {
                 return true;
             }


### PR DESCRIPTION
`StackOverflowException` cannot be caught. See the [**Remarks** section of `StackOverflowException` documentation](https://docs.microsoft.com/en-us/dotnet/api/system.stackoverflowexception?redirectedfrom=MSDN&view=net-5.0#remarks):

> Starting with the .NET Framework 2.0, you can't catch a `StackOverflowException` object with a `try`/`catch` block, and the corresponding process is terminated by default.

This PR therefore removes the check from `IsFatal` method from `FunctionControllerBase`.
