### PR TITLE
Move fatal check into exception filter without override

### DIFF
--- a/src/Infrastructure/FunctionControllerBase.cs
+++ b/src/Infrastructure/FunctionControllerBase.cs
@@ -220,7 +220,7 @@
             {
                 return await fn().ConfigureAwait(false);
             }
-            catch (Exception ex)
+            catch (Exception ex) when (!IsFatal(ex))
             {
                 if (TryHandleError(ex, out var errorResponse))
                 {

--- a/src/Infrastructure/FunctionControllerBase.cs
+++ b/src/Infrastructure/FunctionControllerBase.cs
@@ -154,8 +154,7 @@
         /// </returns>
         protected virtual bool TryHandleError(Exception ex, out IActionResult response)
         {
-            // Let fatal exception go through
-            if (ex != null && IsFatal(ex))
+            if (ex == null)
             {
                 response = null;
                 return false;
@@ -202,7 +201,7 @@
             {
                 return fn();
             }
-            catch (Exception ex)
+            catch (Exception ex) when (!IsFatal(ex))
             {
                 if (TryHandleError(ex, out var errorResponse))
                 {


### PR DESCRIPTION
With this PR, I'd like to suggest moving the `IsFatal` call out of `TryHandleError` and into an exception filter at the catch site. Moving it out of `TryHandleError` ensures that a subclass that overrides the function but forgets to call the base implementation won't end up circumventing the catching of what's considered a fatal exception (unless that is desired, in which case it's better to make `IsFatal` protected and virtual and still use it in the filter).
